### PR TITLE
release: sourcegraph@3.28.0

### DIFF
--- a/resources/amazon-linux2.sh
+++ b/resources/amazon-linux2.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export SOURCEGRAPH_VERSION=3.27.5
+export SOURCEGRAPH_VERSION=3.28.0
 export SOURCEGRAPH_CONFIG=/etc/sourcegraph
 export SOURCEGRAPH_DATA=/var/opt/sourcegraph
 export PATH=$PATH:/usr/local/bin


### PR DESCRIPTION
This pull request is part of the Sourcegraph 3.28.0 release.


* [Release campaign](https://k8s.sgdev.org/organizations/sourcegraph/campaigns/release-sourcegraph-3.28.0)
* [Tracking issue](https://github.com/sourcegraph/sourcegraph/issues/20996)